### PR TITLE
r5rs-doc: add license metadata using SchemeReport

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ for the full text of the licenses.
 
 This repository contains the text of the R5RS standard, in
 r5rs-doc/r5rs/scribblings/. That document is
-distributed with the following license:
+distributed under the SchemeReport license:
 
     We intend this report to belong to the entire Scheme community,
     and so we grant permission to copy it in whole or in part without

--- a/r5rs-doc/info.rkt
+++ b/r5rs-doc/info.rkt
@@ -15,10 +15,5 @@
 
 (define pkg-authors '(mflatt))
 
-;; TODO:
-;; Once <https://tools.spdx.org/app/license_requests/126/>
-;; is accepted (see <https://github.com/spdx/license-list-XML/issues/1340>),
-;; uncomment this:
-#;
 (define license
   '(SchemeReport AND (Apache-2.0 OR MIT)))


### PR DESCRIPTION
Also, rename LICENSE to LICENSE.txt for consistency and adjust it
to refer to the new SchemeReport SPDX license identifier.

According to the note at the end of
<https://github.com/spdx/license-list-XML/blob/f9911cd/DOCS/request-new-license.md>:

  > Once a license has been accepted to be added to the SPDX
  > License List, it is fine to start using the SPDX identifier,
  > even if the official release has not yet occurred.

Related to https://github.com/racket/r5rs/pull/4
Related to https://github.com/spdx/license-list-XML/issues/1340
Related to https://github.com/spdx/license-list-XML/pull/1362
Related to https://github.com/racket/racket/pull/3760