### PR TITLE
Repair `case` on "weird" clauses.

### DIFF
--- a/r5rs-lib/r5rs/main.rkt
+++ b/r5rs-lib/r5rs/main.rkt
@@ -459,7 +459,7 @@
                                     [els (#%expression rhs) ...]))]
                                [[datums rhs ...]
                                 (syntax/loc clause
-                                  [(memv v '(datums)) (#%expression rhs) ...])]))
+                                  [(memv v 'datums) (#%expression rhs) ...])]))
                            (cddr (syntax->list stx)))])
          (syntax/loc stx
            (let ([v expr])


### PR DESCRIPTION
Closes racket/racket#5105.